### PR TITLE
Fixing changes to letsencrypt renewer. Issue #34

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ service nginx reload
 - create a cron for automatic renewal:
 ```
 crontab -e
-30 02 * * * /root/.local/share/letsencrypt/bin/letsencrypt-renewer >> /var/log/ispconfig/cron.log; done
+30 02 * * * /root/.local/share/letsencrypt/bin/letsencrypt renew >> /var/log/ispconfig/cron.log; done
 ```
 
 - sql queries:

--- a/install.php
+++ b/install.php
@@ -70,19 +70,15 @@ if(!file_exists($backup_dir . $backup_file )) {
 echo "Backup finished\n";
 
 if(!is_dir("/etc/letsencrypt")) {
-	echo "ERROR: Let's Encrypt directory ( /etc/letsencrypt/ ) is missing, install it corecctly!\n";
+	echo "ERROR: Let's Encrypt directory ( /etc/letsencrypt/ ) is missing, install it corectly!\n";
 	exit;
 }
 
 if(!is_file("/root/.local/share/letsencrypt/bin/letsencrypt")) {
-	echo "ERROR: Let's Encrypt ( /root/.local/share/letsencrypt/bin/letsencrypt ) is missing, install it corecctly!\n";
+	echo "ERROR: Let's Encrypt ( /root/.local/share/letsencrypt/bin/letsencrypt ) is missing, install it corectly!\n";
 	exit;
 }
 
-if(!is_file("/root/.local/share/letsencrypt/bin/letsencrypt-renewer")) {
-	echo "ERROR: Let's Encrypt ( /root/.local/share/letsencrypt/bin/letsencrypt-renewer ) is missing, install it corecctly!\n";
-	exit;
-}
 
 if(is_file("/etc/letsencrypt/cli.ini")) {
 	echo "Let's Encrypt configuration file exist, backup up and remove.\n";
@@ -137,10 +133,10 @@ if(!file_exists($backup_dir . $backup_file2 )) {
 
 exec("crontab -l", $output);
 
-if(!in_array("30 02 * * * /root/.local/share/letsencrypt/bin/letsencrypt-renewer >> /var/log/ispconfig/cron.log; done", $output)) {
+if(!in_array("30 02 * * * /root/.local/share/letsencrypt/bin/letsencrypt renew >> /var/log/ispconfig/cron.log; done", $output)) {
 	echo "Add a cronjob for renewal certs\n";
 
-	$output[] = "30 02 * * * /root/.local/share/letsencrypt/bin/letsencrypt-renewer >> /var/log/ispconfig/cron.log; done";
+	$output[] = "30 02 * * * /root/.local/share/letsencrypt/bin/letsencrypt renew >> /var/log/ispconfig/cron.log; done";
 
 	exec("touch ./crontab.tmp");
 	if(!is_file("./crontab.tmp")) {


### PR DESCRIPTION
Lets encrypt change in syntax from 'letsencrypt-renewer' to 'letsencrypt renew'
This also rendered the check for the /bin/letsencrypt-renewer file obsolete, so that was removed. 
